### PR TITLE
Skip use_frozen_keys if attrs is already supplied as a Hash

### DIFF
--- a/lib/stockboy/candidate_record.rb
+++ b/lib/stockboy/candidate_record.rb
@@ -17,7 +17,7 @@ module Stockboy
     #
     def initialize(attrs, map)
       @map = map
-      @table = use_frozen_keys(attrs, map)
+      @table = reuse_frozen_hash_keys(attrs, map)
       @tr_table = Hash.new
       freeze
     end
@@ -118,7 +118,8 @@ module Stockboy
       value.is_a?(String) ? value.to_s : value
     end
 
-    def use_frozen_keys(attrs, map)
+    def reuse_frozen_hash_keys(attrs, map)
+      return attrs unless attrs.is_a? Hash
       attrs.reduce(Hash.new) do |new_hash, (field, value)|
         key = map.attribute_from(field).from
         new_hash[key] = value


### PR DESCRIPTION
Skip use_frozen_keys if attrs is already supplied as a Hash
Rename method to be more descriptive
