### PR TITLE
Botch the DSL to pass through attributes array if it contains more than ...

### DIFF
--- a/lib/stockboy/dsl.rb
+++ b/lib/stockboy/dsl.rb
@@ -39,7 +39,11 @@ module Stockboy
           if arg.empty?
             @instance.#{attr}
           else
-            @instance.#{attr} = arg.first
+            if arg.is_a?(Array) && arg.size == 1
+              @instance.#{attr} = arg.first
+            else
+              @instance.#{attr} = arg
+            end
           end
         end
         def #{attr}=(arg)

--- a/lib/stockboy/providers/http.rb
+++ b/lib/stockboy/providers/http.rb
@@ -31,7 +31,7 @@ module Stockboy::Providers
     # @example
     #   post 'http://example.com/api/search'
     #
-    dsl_attr :post, attr_writer: false
+    dsl_attr :post, attr_accessor: false
 
     # HTTP method: +:get+ or +:post+
     #
@@ -87,6 +87,24 @@ module Stockboy::Providers
     #
     dsl_attr :query
 
+    def post_body
+      return nil unless post?
+      @post_body
+    end
+
+    def post_body=(post_body)
+      @post_body = post_body
+    end
+
+    # POST body for setting directly on a request
+    #
+    # @!attribute [rw] post_body
+    # @return [String]
+    # @example
+    #   post_body '<somexml>'
+    #
+    dsl_attr :post_body, attr_accessor: false, alias: :body
+
     def method=(http_method)
       return @method = nil unless %w(get post).include? http_method.to_s.downcase
       @method = http_method.to_s.downcase.to_sym
@@ -97,9 +115,12 @@ module Stockboy::Providers
       @uri = uri
     end
 
-    def post=(uri)
+    def post=(*attrs)
+      attrs = Array(attrs).flatten
+      options = attrs.last.is_a?(Hash) ? attrs.pop : {} # extract_options
       @method = :post
-      @uri = uri
+      @uri = attrs.first
+      @post_body = options[:body]
     end
 
     def username=(username)
@@ -127,6 +148,7 @@ module Stockboy::Providers
     def client
       orig_logger, HTTPI.logger = HTTPI.logger, logger
       req = HTTPI::Request.new.tap { |c| c.url = uri }
+      req.body = post_body if post_body
       req.auth.basic(username, password) if username && password
       block_given? ? yield(req) : req
     ensure
@@ -152,5 +174,8 @@ module Stockboy::Providers
       end
     end
 
+    def post?
+      method == :post
+    end
   end
 end

--- a/spec/stockboy/providers/http_spec.rb
+++ b/spec/stockboy/providers/http_spec.rb
@@ -54,6 +54,14 @@ module Stockboy
         provider.query.should  == { user: 'u' }
         provider.method.should == :get
       end
+
+      it "sets the post body when passed" do
+        provider = Providers::HTTP.new do
+          post   "http://www.example.com/", body: "body"
+        end
+
+        provider.post_body.should == "body"
+      end
     end
 
     describe "validation" do
@@ -72,6 +80,14 @@ module Stockboy
       end
     end
 
+    describe "#post_body" do
+      it "should return nil for get requests" do
+        provider.post_body = "body"
+        provider.method = :get
+        provider.post_body.should be_nil
+      end
+    end
+
     describe "#client" do
       subject(:client) { provider.client }
 
@@ -79,6 +95,12 @@ module Stockboy
 
       it "should configure the base url" do
         client.url.host.should == "example.com"
+      end
+
+      it "should set the post body value" do
+        provider.method = :post
+        provider.post_body = "body"
+        client.body.should == "body"
       end
 
       it "returns the value of the passed block" do


### PR DESCRIPTION
...one element

Allow HTTP provider post to accept array in order to set the HTTPI::Request body directly

This seems like a super clumsy solution but does open up DSL writers to accept options which I'm sure would be useful elsewhere, there's probably a more elegant solution to get what I'm trying to achieve...