### PR TITLE
let pick accept proc with single argument

### DIFF
--- a/lib/stockboy/provider.rb
+++ b/lib/stockboy/provider.rb
@@ -162,7 +162,7 @@ module Stockboy
       when Symbol
         list.public_send @pick
       when Proc
-        list.reduce &@pick
+        @pick.arity == 1 ? @pick.call(list) : list.reduce(&@pick)
       end
     end
 


### PR DESCRIPTION
The documentation for pick suggests that a proc accepting just the file list as a parameter can be used (https://github.com/avit/stockboy/blob/master/lib/stockboy/provider.rb#L183 , https://github.com/avit/stockboy/blob/master/lib/stockboy/providers/ftp.rb#L22). However reduce requires a proc taking two arguments. 

Suggested change conforms to examples in docs and shouldn't break existing usage.
