### PR TITLE
Allow user defined variables to be injected at Job definition to be used in the DSL

### DIFF
--- a/lib/stockboy/configurator.rb
+++ b/lib/stockboy/configurator.rb
@@ -19,6 +19,7 @@ module Stockboy
     # @return [Hash]
     #
     attr_reader :config
+    attr_reader :env
 
     # Evaluate DSL and capture configuration for building a job
     #
@@ -34,7 +35,8 @@ module Stockboy
       @config[:triggers] = Hash.new { |hash, key| hash[key] = [] }
       @config[:filters] = {}
 
-      env.merge! env_variables
+      @env = EnvVars.new(env_variables)
+      @config[:env] = @env
 
       if block_given?
         instance_eval(&block)
@@ -170,12 +172,6 @@ module Stockboy
       @config[:filters][key] = filter
     end
 
-    def env
-      @config[:env] ||= Hash.new do |hash, key|
-        raise DSLEnvVariableUndefined, "#{key} not defined"
-      end
-    end
-
     # Register a trigger to notify the job of external events
     #
     # Useful for adding generic control over the job's resources from your app.
@@ -220,6 +216,25 @@ module Stockboy
     def wrap_provider(config)
       return unless (repeat = config.delete(:repeat))
       config[:provider] = ProviderRepeater.new(config[:provider], &repeat)
+    end
+
+    # Store for template variables to be used in the DSL.
+    #
+    # A "frozen" copy is made of any values passed, such that template variables are
+    # locked at job definition time. To use a different set of variables, the job must
+    # be re-defined.
+    #
+    class EnvVars
+        def initialize(variables)
+            @h = Hash.new do |hash, key|
+                raise DSLEnvVariableUndefined, "#{key} not defined"
+            end
+            @h.merge!(Marshal.load(Marshal.dump(variables)))
+        end
+
+        def [](key)
+            @h[key].dup
+        end
     end
 
   end

--- a/lib/stockboy/configurator.rb
+++ b/lib/stockboy/configurator.rb
@@ -171,7 +171,7 @@ module Stockboy
     end
 
     def env
-      @env ||= Hash.new do |hash, key|
+      @config[:env] ||= Hash.new do |hash, key|
         raise DSLEnvVariableUndefined, "#{key} not defined"
       end
     end

--- a/lib/stockboy/configurator.rb
+++ b/lib/stockboy/configurator.rb
@@ -29,10 +29,16 @@ module Stockboy
     # @overload new(&block)
     #   Evaluate DSL in a block
     #
-    def initialize(dsl='', file=__FILE__, &block)
+    def initialize(dsl='', file=__FILE__, inject_variables={}, &block)
       @config = {}
       @config[:triggers] = Hash.new { |hash, key| hash[key] = [] }
       @config[:filters] = {}
+
+      inject_variables.each do |k, v|
+        raise DSLVariableCollision if instance_variable_defined?("@#{k}")
+        instance_variable_set("@#{k}", v)
+      end
+
       if block_given?
         instance_eval(&block)
       else

--- a/lib/stockboy/exceptions.rb
+++ b/lib/stockboy/exceptions.rb
@@ -22,5 +22,5 @@ module Stockboy
     attr_reader :record
   end
 
-  class DSLVariableCollision < StandardError; end
+  class DSLEnvVariableUndefined < StandardError; end
 end

--- a/lib/stockboy/exceptions.rb
+++ b/lib/stockboy/exceptions.rb
@@ -21,4 +21,6 @@ module Stockboy
     attr_reader :key
     attr_reader :record
   end
+
+  class DSLVariableCollision < StandardError; end
 end

--- a/lib/stockboy/job.rb
+++ b/lib/stockboy/job.rb
@@ -97,9 +97,9 @@ module Stockboy
     # @yield instance for further configuration or processing
     # @see Configuration#template_load_paths
     #
-    def self.define(template_name)
+    def self.define(template_name, template_variables={})
       return nil unless template = TemplateFile.read(template_name)
-      job = Configurator.new(template, TemplateFile.find(template_name)).to_job
+      job = Configurator.new(template, TemplateFile.find(template_name), template_variables).to_job
       yield job if block_given?
       job
     end

--- a/lib/stockboy/job.rb
+++ b/lib/stockboy/job.rb
@@ -94,6 +94,7 @@ module Stockboy
     # Instantiate a job configured by DSL template file
     #
     # @param template_name [String] File basename from template load path
+    # @param template_variables [Hash] env variables to be 'injected' into the template
     # @yield instance for further configuration or processing
     # @see Configuration#template_load_paths
     #

--- a/lib/stockboy/job.rb
+++ b/lib/stockboy/job.rb
@@ -55,9 +55,9 @@ module Stockboy
 
     # Env variables passed to the job template DSL
     #
-    # @return [Hash]
+    # @return [Configurator::EnvVars]
     #
-    attr_accessor :env
+    attr_reader :env
 
     # Lists of records grouped by filter key
     #

--- a/lib/stockboy/job.rb
+++ b/lib/stockboy/job.rb
@@ -53,6 +53,12 @@ module Stockboy
 
     attr_reader :triggers
 
+    # Env variables passed to the job template DSL
+    #
+    # @return [Hash]
+    #
+    attr_accessor :env
+
     # Lists of records grouped by filter key
     #
     # @return [Hash{Symbol=>Array}]
@@ -87,6 +93,7 @@ module Stockboy
       @filters    = FilterChain.new params[:filters]
       @triggers   = Hash.new { |h,k| h[k] = [] }
       @triggers.replace params[:triggers] if params[:triggers]
+      @env        = params[:env]
       yield self if block_given?
       reset
     end

--- a/spec/stockboy/configurator_spec.rb
+++ b/spec/stockboy/configurator_spec.rb
@@ -166,12 +166,29 @@ module Stockboy
     end
 
     describe "#env" do
-      it "returns a Hash" do
-        expect(subject.env).to be_a(Hash)
+      it "returns a Configurator::EnvVars object" do
+        expect(subject.env).to be_a(Configurator::EnvVars)
+      end
+    end
+
+    describe "EnvVars" do
+      let(:initial_vars) { {:test_key => "test value"} }
+      let(:env_vars) { Configurator::EnvVars.new(initial_vars) }
+
+      it "can be read like a Hash" do
+        expect(env_vars).to respond_to(:[])
       end
 
       it "raises an error when an undefined env variable is used" do
-        expect{subject.env[:my_undefined_key]}.to raise_error DSLEnvVariableUndefined
+        expect{env_vars[:my_undefined_key]}.to raise_error DSLEnvVariableUndefined
+      end
+
+      it "'s values are immutable" do
+        new_value = env_vars[:test_key]  << "appended string"
+        expect(env_vars[:test_key]).not_to eq new_value
+
+        initial_vars[:test_key] << "+mutating inputs"
+        expect(env_vars[:test_key]).to eq "test value"
       end
 
     end

--- a/spec/stockboy/configurator_spec.rb
+++ b/spec/stockboy/configurator_spec.rb
@@ -165,6 +165,17 @@ module Stockboy
 
     end
 
+    describe "#env" do
+      it "returns a Hash" do
+        expect(subject.env).to be_a(Hash)
+      end
+
+      it "raises an error when an undefined env variable is used" do
+        expect{subject.env[:my_undefined_key]}.to raise_error DSLEnvVariableUndefined
+      end
+
+    end
+
     describe "#to_job" do
       before do
         Providers.register :test_prov, provider_class


### PR DESCRIPTION
Proposed usage:

When declaring a Job
`Stockboy::Job.define('template_name', {my_dsl_var: "my dsl var value"})`

Then in the dsl
`filter :example_filter, proc{ |i,o| i.some_attribute == @my_dsl_var } `